### PR TITLE
Switch order of equality & condition expectations

### DIFF
--- a/tests/testthat/test-taylor-album-palettes.R
+++ b/tests/testthat/test-taylor-album-palettes.R
@@ -55,8 +55,9 @@ test_that("direction works", {
 
 test_that("bad album warns", {
   expect_warning(taylor_col(5, album = "sour"), "does not exist")
-  expect_identical(expect_warning(taylor_col(5, album = "sour")),
-                   taylor_col(5, album = "Lover"))
+  expect_warning(
+    expect_identical(taylor_col(5, album = "sour"), taylor_col(5, album = "Lover"))
+  )
 })
 
 test_that("we get expected values", {


### PR DESCRIPTION
In the dev version of testthat, we've tweaked `expect_warning()` and friends to return output that's [more consistent](https://github.com/r-lib/testthat/blob/master/NEWS.md#breaking-changes) with other testthat expectations. We'd like to get testthat on to CRAN in the near future, so I'd really appreciate it if you could merge this change and update your package on CRAN.