### PR TITLE
Refactor tests to use snapshots and `abort_bad_argument()`

### DIFF
--- a/R/data-checks.R
+++ b/R/data-checks.R
@@ -1,18 +1,16 @@
 # Checkers ---------------------------------------------------------------------
-abort_bad_argument <- function(arg, must, not = NULL, extra = NULL,
-                               custom = NULL, call) {
+abort_bad_argument <- function(arg, must = NULL, not = NULL, footer = NULL,
+                               custom = NULL, call = rlang::caller_env()) {
   msg <- "{.arg {arg}} must {must}"
   if (!is.null(not)) {
     msg <- paste0(msg, "; not {not}")
   }
-  if (!is.null(extra)) {
-    msg <- c(msg, extra)
-  }
   if (!is.null(custom)) {
     msg <- custom
+    footer <- NULL
   }
 
-  cli::cli_abort(msg, call = call)
+  cli::cli_abort(msg, footer = footer, call = call)
 }
 
 check_palette <- function(x, arg = rlang::caller_arg(x),
@@ -46,7 +44,7 @@ check_palette <- function(x, arg = rlang::caller_arg(x),
     abort_bad_argument(
       arg = arg,
       must = "be valid hexadecimal values or from `colors()`.",
-      extra = cli::format_message(
+      footer = cli::format_message(
         c(i = "Problematic value{?s}: {.val {x[!valid_hex]}}.")
       ),
       call = call

--- a/R/data-checks.R
+++ b/R/data-checks.R
@@ -21,7 +21,7 @@ check_palette <- function(x, arg = rlang::caller_arg(x),
   }
 
   # make sure no missing values present
-  if (any(rlang::are_na(x))) {
+  if (anyNA(x) || !rlang::is_atomic(x)) {
     abort_bad_argument(arg = arg, must = "not contain missing values",
                        call = call)
   }

--- a/tests/testthat/_snaps/data-checks.md
+++ b/tests/testthat/_snaps/data-checks.md
@@ -1,0 +1,167 @@
+# abort_bad_argument() is informative.
+
+    Code
+      abort_bad_argument("size", "be an integer", not = "character")
+    Condition
+      Error:
+      ! `size` must be an integer; not character
+    Code
+      abort_bad_argument("size", must = "be an integer", not = "character", footer = c(
+        i = "please"))
+    Condition
+      Error:
+      ! `size` must be an integer; not character
+      i please
+    Code
+      abort_bad_argument("size", must = "be an integer", not = "character", footer = "required",
+        custom = "A new error")
+    Condition
+      Error:
+      ! A new error
+
+# abort_bad_argument() can add inline markup to footer
+
+    Code
+      a_local_variable <- "local var"
+      footer <- cli::format_message(c(x = "Look at {.val {a_local_var}}"))
+    Condition
+      Error:
+      ! Could not evaluate cli `{}` expression: `a_local_var`.
+      Caused by error:
+      ! object 'a_local_var' not found
+    Code
+      abort_bad_argument("size", "be an integer", footer = footer)
+    Condition
+      Error:
+      ! object 'footer' not found
+
+# check_palette() throws informative error.
+
+    Code
+      check_palette(2)
+    Condition
+      Error:
+      ! `2` must be a character vector; not double
+    Code
+      check_palette(NA_character_)
+    Condition
+      Error:
+      ! `NA_character_` must not contain missing values
+
+---
+
+    Code
+      x <- c("#009fb7", "firetruck")
+      check_palette(x)
+    Condition
+      Error:
+      ! `x` must be valid hexadecimal values or from `colors()`.
+      i Problematic value: "firetruck".
+
+# check_pos_int() errors well
+
+    Code
+      check_pos_int("blue")
+    Condition
+      Error:
+      ! `"blue"` must be numeric; not character
+    Code
+      check_pos_int(NA_integer_, "taylor")
+    Condition
+      Error:
+      ! `taylor` must be non-missing
+    Code
+      check_pos_int(integer(0L))
+    Condition
+      Error:
+      ! `integer(0L)` must have length of 1; not 0
+    Code
+      check_pos_int(2:3)
+    Condition
+      Error:
+      ! `2:3` must have length of 1; not 2
+    Code
+      check_pos_int(-2)
+    Condition
+      Error:
+      ! `-2L` must be greater than 0
+
+# check_real_range() works
+
+    Code
+      check_real_range("a", 0, 1, "taylor")
+    Condition
+      Error:
+      ! `taylor` must be numeric; not character
+    Code
+      check_real_range(NA_integer_, 1, 5)
+    Condition
+      Error:
+      ! `NA_integer_` must be non-missing
+    Code
+      check_real_range(integer(0L), 1, 5)
+    Condition
+      Error:
+      ! `integer(0L)` must have length of 1; not 0
+    Code
+      check_real_range(2:3, 0, 1)
+    Condition
+      Error:
+      ! `2:3` must have length of 1; not 2
+    Code
+      check_real_range(2, 0, 1)
+    Condition
+      Error:
+      ! `2` must be between 0 and 1
+    Code
+      check_real_range(-1, 0, 1)
+    Condition
+      Error:
+      ! `-1` must be between 0 and 1
+
+# check_exact_abs_int() errors well
+
+    Code
+      check_exact_abs_int("a", 1)
+    Condition
+      Error:
+      ! `"a"` must be numeric; not character
+    Code
+      check_exact_abs_int(NA_integer_, 1)
+    Condition
+      Error:
+      ! `NA_integer_` must be non-missing
+    Code
+      check_exact_abs_int(integer(0), 1)
+    Condition
+      Error:
+      ! `integer(0)` must have length of 1; not 0
+    Code
+      check_exact_abs_int(2:3, 1)
+    Condition
+      Error:
+      ! `2:3` must have length of 1; not 2
+    Code
+      check_exact_abs_int(3, 1)
+    Condition
+      Error:
+      ! `3` must be 1 or -1
+    Code
+      check_exact_abs_int(3, 4)
+    Condition
+      Error:
+      ! `3` must be 4 or -4
+
+# check_character() errors well
+
+    Code
+      check_character(1, arg = "taylor")
+    Condition
+      Error:
+      ! `taylor` must be character; not double
+    Code
+      check_character(NA_character_)
+    Condition
+      Error:
+      ! `NA_character_` must be non-missing
+

--- a/tests/testthat/_snaps/data-checks.md
+++ b/tests/testthat/_snaps/data-checks.md
@@ -23,17 +23,12 @@
 
     Code
       a_local_variable <- "local var"
-      footer <- cli::format_message(c(x = "Look at {.val {a_local_var}}"))
-    Condition
-      Error:
-      ! Could not evaluate cli `{}` expression: `a_local_var`.
-      Caused by error:
-      ! object 'a_local_var' not found
-    Code
+      footer <- cli::format_message(c(x = "Look at {.val {a_local_variable}}"))
       abort_bad_argument("size", "be an integer", footer = footer)
     Condition
       Error:
-      ! object 'footer' not found
+      ! `size` must be an integer
+      x Look at "local var"
 
 # check_palette() throws informative error.
 

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -1,0 +1,13 @@
+# capitalization works
+
+    Code
+      title_case(2)
+    Condition
+      Error:
+      ! `string` must be character; not double
+    Code
+      title_case(NA_character_)
+    Condition
+      Error:
+      ! `string` must be non-missing
+

--- a/tests/testthat/_snaps/palette.md
+++ b/tests/testthat/_snaps/palette.md
@@ -1,9 +1,28 @@
+# palette creation work
+
+    Code
+      color_palette(c("firetruck", "ocean"))
+    Condition
+      Error in `color_palette()`:
+      ! `pal` must be valid hexadecimal values or from `colors()`.
+      i Problematic values: "firetruck" and "ocean".
+    Code
+      color_palette(c("#00ZVPQ", "#IOBNOB"))
+    Condition
+      Error in `color_palette()`:
+      ! `pal` must be valid hexadecimal values or from `colors()`.
+      i Problematic values: "#00ZVPQ" and "#IOBNOB".
+    Code
+      color_palette(c("#00ZVPQ", "red"))
+    Condition
+      Error in `color_palette()`:
+      ! `pal` must be valid hexadecimal values or from `colors()`.
+      i Problematic value: "#00ZVPQ".
+
 # various formatting works
 
     Code
-      df1 <- tibble::tibble(red = album_palettes$red, evermore = album_palettes$
-        evermore)
-      print(df1)
+      df1
     Output
       # A tibble: 5 x 2
         red     evermore
@@ -17,7 +36,7 @@
 ---
 
     Code
-      print(album_palettes$lover)
+      album_palettes$lover
     Output
       <color_palette[5]>
           #76BAE0 
@@ -25,8 +44,11 @@
           #B8396B 
           #EBBED3 
           #FFF5CC 
+
+---
+
     Code
-      print(album_palettes$folklore)
+      album_palettes$folklore
     Output
       <color_palette[5]>
           #3E3E3E 
@@ -38,35 +60,27 @@
 ---
 
     Code
-      col1 <- c("wheat", "firebrick", "navy")
-      col2 <- c("#009fb7", "#fed766", "#696773")
-      col3 <- c("goldenrod", "#85898a")
-      col4 <- c(ku_blue = "#0051ba", ku_crimson = "#e8000d", "#ffc82d")
-      pal1 <- color_palette(col1)
-      pal2 <- color_palette(col2)
-      pal3 <- color_palette(col3)
-      pal4 <- color_palette(col4)
-      print(pal1)
+      color_palette(col1)
     Output
       <color_palette[3]>
           wheat 
           firebrick 
           navy 
     Code
-      print(pal2)
+      color_palette(col2)
     Output
       <color_palette[3]>
           #009fb7 
           #fed766 
           #696773 
     Code
-      print(pal3)
+      color_palette(col3)
     Output
       <color_palette[2]>
           goldenrod 
           #85898a 
     Code
-      print(pal4)
+      color_palette(col4)
     Output
       <color_palette[3]>
           ku_blue 

--- a/tests/testthat/_snaps/taylor-album-palettes.md
+++ b/tests/testthat/_snaps/taylor-album-palettes.md
@@ -1,0 +1,36 @@
+# taylor_col() throws informative error.
+
+    Code
+      taylor_col(5, begin = -1)
+    Condition
+      Error in `taylor_col()`:
+      ! `begin` must be between 0 and 1
+    Code
+      taylor_col(5, begin = 2)
+    Condition
+      Error in `taylor_col()`:
+      ! `begin` must be between 0 and 1
+    Code
+      taylor_col(5, end = -1)
+    Condition
+      Error in `taylor_col()`:
+      ! `end` must be between 0 and 1
+    Code
+      taylor_col(5, end = 2)
+    Condition
+      Error in `taylor_col()`:
+      ! `end` must be between 0 and 1
+
+---
+
+    Code
+      taylor_col(5, direction = 2)
+    Condition
+      Error in `taylor_col()`:
+      ! `direction` must be 1 or -1
+    Code
+      taylor_col(5, direction = -3)
+    Condition
+      Error in `taylor_col()`:
+      ! `direction` must be 1 or -1
+

--- a/tests/testthat/test-data-checks.R
+++ b/tests/testthat/test-data-checks.R
@@ -16,7 +16,7 @@ test_that("abort_bad_argument() is informative.", {
 test_that("abort_bad_argument() can add inline markup to footer", {
   expect_snapshot(error = TRUE, {
     a_local_variable <- "local var"
-    footer <- cli::format_message(c("x" = "Look at {.val {a_local_var}}"))
+    footer <- cli::format_message(c("x" = "Look at {.val {a_local_variable}}"))
     abort_bad_argument("size", "be an integer", footer = footer)
   })
 })

--- a/tests/testthat/test-data-checks.R
+++ b/tests/testthat/test-data-checks.R
@@ -1,182 +1,124 @@
-test_that("abort_bad_argument", {
-  err <- rlang::catch_cnd(abort_bad_argument("size", must = "be an integer",
-                                             call = rlang::caller_env()))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "be an integer")
-
-  err <- rlang::catch_cnd(abort_bad_argument("size", must = "be an integer",
-                                             not = "character",
-                                             call = rlang::caller_env()))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "be an integer; not character")
-
-  err <- rlang::catch_cnd(abort_bad_argument("size", must = "be an integer",
-                                             extra = "please",
-                                             call = rlang::caller_env()))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "be an integer")
-  expect_match(err$body, "please")
-
-  err <- rlang::catch_cnd(abort_bad_argument("size", must = "be an integer",
-                                             not = "character",
-                                             extra = "required",
-                                             call = rlang::caller_env()))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "be an integer; not character")
-  expect_match(err$body, "required")
-
-  err <- rlang::catch_cnd(abort_bad_argument("size", must = "be an integer",
-                                             not = "character",
-                                             extra = "required",
-                                             custom = "A new error",
-                                             call = rlang::caller_env()))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "A new error")
+test_that("abort_bad_argument() is informative.", {
+  expect_error(
+    abort_bad_argument("size", "be an integer"),
+    regexp = "be an integer",
+    class = "rlang_error"
+  )
+  expect_snapshot(error = TRUE, {
+    abort_bad_argument("size", "be an integer", not = "character")
+    abort_bad_argument("size", must = "be an integer", not = "character",
+                       footer = c(i = "please"))
+    abort_bad_argument("size", must = "be an integer", not = "character",
+                       footer = "required", custom = "A new error")
+  })
 })
 
-test_that("check palette works", {
-  x <- 2
-  err <- rlang::catch_cnd(check_palette(x))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`x` must be a character vector; not double")
+test_that("abort_bad_argument() can add inline markup to footer", {
+  expect_snapshot(error = TRUE, {
+    a_local_variable <- "local var"
+    footer <- cli::format_message(c("x" = "Look at {.val {a_local_var}}"))
+    abort_bad_argument("size", "be an integer", footer = footer)
+  })
+})
 
-  x <- NA_character_
-  err <- rlang::catch_cnd(check_palette(x))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`x` must not contain missing values")
 
-  x <- c("#009fb7", "firetruck")
-  err <- rlang::catch_cnd(check_palette(x))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "valid hexadecimal values")
+test_that("check_palette() throws informative error.", {
+  expect_snapshot(error = TRUE, {
+    check_palette(2)
+    check_palette(NA_character_)
+  })
 
-  expect_identical(check_palette(c("#009fb7", "#fed766")),
-                   c(`#009fb7` = "#009fb7", `#fed766` = "#fed766"))
-  expect_identical(check_palette(c("#009fb700", "#fed766ff")),
-                   c(`#009fb700` = "#009fb700", `#fed766ff` = "#fed766ff"))
-  expect_identical(check_palette(c("firebrick", "goldenrod", "navy")),
-                   c(firebrick = "#B22222", goldenrod = "#DAA520",
-                     navy = "#000080"))
-  expect_identical(check_palette(c("firebrick", "#009fb7", "#FED766")),
-                   c(firebrick = "#B22222", `#009fb7` = "#009fb7",
-                     `#FED766` = "#FED766"))
+  expect_snapshot(error = TRUE, {
+    x <- c("#009fb7", "firetruck")
+    check_palette(x)
+  })
+})
+
+test_that("check_palette() works", {
+  expect_identical(
+    check_palette(c("#009fb7", "#fed766")),
+    c(`#009fb7` = "#009fb7", `#fed766` = "#fed766")
+  )
+  expect_identical(
+    check_palette(c("#009fb700", "#fed766ff")),
+    c(`#009fb700` = "#009fb700", `#fed766ff` = "#fed766ff")
+  )
+  expect_identical(
+    check_palette(c("firebrick", "goldenrod", "navy")),
+    c(
+      firebrick = "#B22222", goldenrod = "#DAA520",
+      navy = "#000080"
+    )
+  )
+  expect_identical(
+    check_palette(c("firebrick", "#009fb7", "#FED766")),
+    c(
+      firebrick = "#B22222", `#009fb7` = "#009fb7",
+      `#FED766` = "#FED766"
+    )
+  )
+})
+
+test_that("check_pos_int() errors well", {
+  expect_snapshot(error = TRUE, {
+    check_pos_int("blue")
+    check_pos_int(NA_integer_, "taylor")
+    check_pos_int(integer(0L))
+    check_pos_int(2:3)
+    check_pos_int(-2)
+  })
 })
 
 test_that("check positive integer works", {
-  blue <- "blue"
-  err <- rlang::catch_cnd(check_pos_int(blue))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`blue` must be numeric; not character")
-
-  taylor <- NA_integer_
-  err <- rlang::catch_cnd(check_pos_int(taylor))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`taylor` must be non-missing")
-
-  test <- integer()
-  err <- rlang::catch_cnd(check_pos_int(test))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`test` must have length of 1; not 0")
-
-  test <- c(2:3)
-  err <- rlang::catch_cnd(check_pos_int(test))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "test` must have length of 1; not 2")
-
-  err <- rlang::catch_cnd(check_pos_int(-2))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "greater than 0")
-
   expect_identical(check_pos_int(0), 0L)
   expect_identical(check_pos_int(3), 3L)
   expect_identical(check_pos_int(5L), 5L)
   expect_identical(check_pos_int(10L), 10L)
 })
 
+test_that("check_real_range() works", {
+  expect_snapshot(error = TRUE, {
+    check_real_range("a", 0, 1, "taylor")
+    check_real_range(NA_integer_, 1, 5)
+    check_real_range(integer(0L), 1, 5)
+    check_real_range(2:3, 0, 1)
+    check_real_range(2, 0, 1)
+    check_real_range(-1, 0, 1)
+  })
+})
+
 test_that("real range works", {
-  taylor <- "a"
-  err <- rlang::catch_cnd(check_real_range(taylor, 0, 1))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`taylor` must be numeric; not character")
-
-  travis <- NA_integer_
-  err <- rlang::catch_cnd(check_real_range(travis, 1, 5))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`travis` must be non-missing")
-
-  meredith <- integer()
-  err <- rlang::catch_cnd(check_real_range(meredith, 1, 5))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`meredith` must have length of 1; not 0")
-
-  olivia <- c(2:3)
-  err <- rlang::catch_cnd(check_real_range(olivia, 1, 5))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`olivia` must have length of 1; not 2")
-
-  benjamin <- 2
-  err <- rlang::catch_cnd(check_real_range(benjamin, 0, 1))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`benjamin` must be between 0 and 1")
-
-  benjamin <- -1
-  err <- rlang::catch_cnd(check_real_range(benjamin, 0, 1))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`benjamin` must be between 0 and 1")
-
   expect_identical(check_real_range(0, 0, 1), 0)
   expect_identical(check_real_range(1, 0, 1), 1)
   expect_identical(check_real_range(0.5, 0, 1), 0.5)
 })
 
+test_that("check_exact_abs_int() errors well", {
+  expect_snapshot(error = TRUE, {
+    check_exact_abs_int("a", 1)
+    check_exact_abs_int(NA_integer_, 1)
+    check_exact_abs_int(integer(0), 1)
+    check_exact_abs_int(2:3, 1)
+    check_exact_abs_int(3, 1)
+    check_exact_abs_int(3, 4)
+  })
+})
+
 test_that("check abs value of exact integer works", {
-  taylor <- "a"
-  err <- rlang::catch_cnd(check_exact_abs_int(taylor, 1))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`taylor` must be numeric; not character")
-
-  travis <- NA_integer_
-  err <- rlang::catch_cnd(check_exact_abs_int(travis, 1))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`travis` must be non-missing")
-
-  meredith <- integer()
-  err <- rlang::catch_cnd(check_exact_abs_int(meredith, 1))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`meredith` must have length of 1; not 0")
-
-  olivia <- c(2:3)
-  err <- rlang::catch_cnd(check_exact_abs_int(olivia, 1))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`olivia` must have length of 1; not 2")
-
-  benjamin <- 3
-  err <- rlang::catch_cnd(check_exact_abs_int(benjamin, 1))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`benjamin` must be 1 or -1")
-
-  benjamin <- 3
-  err <- rlang::catch_cnd(check_exact_abs_int(benjamin, 4))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`benjamin` must be 4 or -4")
-
   expect_identical(check_exact_abs_int(1, 1), 1L)
   expect_identical(check_exact_abs_int(-1, 1), -1L)
   expect_identical(check_exact_abs_int(1L, 1), 1L)
   expect_identical(check_exact_abs_int(-1L, 1), -1L)
 })
 
+test_that("check_character() errors well", {
+  expect_snapshot(error = TRUE, {
+    check_character(1, arg = "taylor")
+    check_character(NA_character_)
+  })
+})
+
 test_that("character works", {
-  taylor <- 1
-  err <- rlang::catch_cnd(check_character(taylor))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`taylor` must be character; not double")
-
-  travis <- NA_character_
-  err <- rlang::catch_cnd(check_character(travis))
-  expect_s3_class(err, "rlang_error")
-  expect_match(err$message, "`travis` must be non-missing")
-
   expect_identical(check_character("string", "test_arg"), "string")
   expect_identical(check_character("String", "test_arg"), "String")
   expect_identical(check_character("STRING", "test_arg"), "STRING")

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -1,6 +1,8 @@
 test_that("capitalization works", {
-  expect_error(title_case(2), "character")
-  expect_error(title_case(NA_character_), "non-missing")
+  expect_snapshot(error = TRUE, {
+    title_case(2)
+    title_case(NA_character_)
+  })
 
   expect_identical(title_case("taylor swift"), "Taylor Swift")
   expect_identical(title_case("TAYLOR SWIFT"), "Taylor Swift")

--- a/tests/testthat/test-palette.R
+++ b/tests/testthat/test-palette.R
@@ -1,7 +1,9 @@
 test_that("palette creation work", {
-  expect_error(color_palette(c("firetruck", "ocean")), "hexadecimal")
-  expect_error(color_palette(c("#00ZVPQ", "#IOBNOB")), "hexadecimal")
-  expect_error(color_palette(c("#00ZVPQ", "red")), "hexadecimal")
+  expect_snapshot(error = TRUE, {
+    color_palette(c("firetruck", "ocean"))
+    color_palette(c("#00ZVPQ", "#IOBNOB"))
+    color_palette(c("#00ZVPQ", "red"))
+  })
 
   wjake_colors <- c("#009fb7", "#fed766")
   wjake_palette <- color_palette(wjake_colors)
@@ -93,32 +95,24 @@ test_that("casting and coercion work", {
 })
 
 test_that("various formatting works", {
-  expect_snapshot({
-    df1 <- tibble::tibble(red = album_palettes$red,
-                          evermore = album_palettes$evermore)
-    print(df1)
-  })
+  df1 <- tibble::tibble(
+    red = album_palettes$red,
+    evermore = album_palettes$evermore
+  )
+  expect_snapshot(df1)
+
+  expect_snapshot(album_palettes$lover)
+  expect_snapshot(album_palettes$folklore)
+
+  col1 <- c("wheat", "firebrick", "navy")
+  col2 <- c("#009fb7", "#fed766", "#696773")
+  col3 <- c("goldenrod", "#85898a")
+  col4 <- c(ku_blue = "#0051ba", ku_crimson = "#e8000d", "#ffc82d")
 
   expect_snapshot({
-    print(album_palettes$lover)
-
-    print(album_palettes$folklore)
-  })
-
-  expect_snapshot({
-    col1 <- c("wheat", "firebrick", "navy")
-    col2 <- c("#009fb7", "#fed766", "#696773")
-    col3 <- c("goldenrod", "#85898a")
-    col4 <- c(ku_blue = "#0051ba", ku_crimson = "#e8000d", "#ffc82d")
-
-    pal1 <- color_palette(col1)
-    pal2 <- color_palette(col2)
-    pal3 <- color_palette(col3)
-    pal4 <- color_palette(col4)
-
-    print(pal1)
-    print(pal2)
-    print(pal3)
-    print(pal4)
+    color_palette(col1)
+    color_palette(col2)
+    color_palette(col3)
+    color_palette(col4)
   })
 })

--- a/tests/testthat/test-taylor-album-palettes.R
+++ b/tests/testthat/test-taylor-album-palettes.R
@@ -32,14 +32,18 @@ test_that("palettes have expected length", {
   expect_identical(names(album_palettes), names(album_compare))
 })
 
-test_that("we get errors", {
-  expect_error(taylor_col(5, begin = -1), "between 0 and 1")
-  expect_error(taylor_col(5, begin = 2), "between 0 and 1")
-  expect_error(taylor_col(5, end = -1), "between 0 and 1")
-  expect_error(taylor_col(5, end = 2), "between 0 and 1")
+test_that("taylor_col() throws informative error.", {
+  expect_snapshot(error = TRUE, {
+    taylor_col(5, begin = -1)
+    taylor_col(5, begin = 2)
+    taylor_col(5, end = -1)
+    taylor_col(5, end = 2)
+  })
 
-  expect_error(taylor_col(5, direction = 2), "be 1 or -1")
-  expect_error(taylor_col(5, direction = -3), "be 1 or -1")
+  expect_snapshot(error = TRUE, {
+    taylor_col(5, direction = 2)
+    taylor_col(5, direction = -3)
+  })
 })
 
 test_that("no colors works", {


### PR DESCRIPTION
Here are a couple extra suggestions when trying to improve error messages.

I highly recommend using snapshot tests, as you can quickly verify that your output changed how you want it.

It is better to add a `call` argument to `abort_bad_argument()` to make testing easier

`expect_snapshot(error = TRUE)` is a lifesaver https://testthat.r-lib.org/articles/snapshotting.html

Also discovered that `abort()` / `cli_abort()` have a dedicated argument to take care of extra info: `footer`, so renamed it to this (and if `custom`, don't show `footer`)

`custom` requires `must`  to be optional.

Edit: made a mistake in the first place that I easily caught with snapshot tests! e8d8868 It is easier to experiment this way